### PR TITLE
Fix parser to match commit cards even if no list is found in the message

### DIFF
--- a/src/server/views/help.ls
+++ b/src/server/views/help.ls
@@ -36,6 +36,8 @@ exports.parse = (list, msg) ->
       commit.list = item.id
       return commit
 
+  return commit
+
 exports.read-file = (url, next) ->
   if url.match(//http//)?
     err, resp, body <- request url


### PR DESCRIPTION
Related to new list-parsing logic introduced in 00816be2
