### PR TITLE
Adding fallback if users file doesn't exist. Removing an unhittable code block

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,18 +12,37 @@ $ git commit -m 'Finalized details done #124'
 
 It will update `card #124`: add commit message + link as comment and move it to a list `done`.  
 
-### Config App
+### Deploy
 
-Below is script for heroku cloud. But you can host at any hosting for node.js.  
+Below is script for heroku cloud. But you can host at any hosting for node.js.
 
 ```
 $ git clone https://github.com/olebedev/hook-to-trello.git myhooks
 $ cd myhooks
+$ heroku create
+$ # Set configuration variables now. See Config App.
+$ git push heroku <current branch>:master
+```
+If deploy was good, you can find application url in stdout. Usual it look like this: `https://sheltered-brook-4402.herokuapp.com`. This _URL_ to be useful in the next step.  
+After that you need setup you repo for webhook. Read about it [here](https://help.github.com/articles/post-receive-hooks) or [here](https://confluence.atlassian.com/display/BITBUCKET/POST+Service+Management).  
+
+### Config App
+
+The app needs at least one Trello key/token pair. How to get `token` & `key` see [below](#key--token).
+
+#### Basic Configuration
+
+Set the `TOKEN` and `KEY` environment variables. This uses the same Trello token and key for every commit. On Heroku:
+```
+$ heroku config:set KEY <your admin board key>
+$ heroku config:set TOKEN <your admin board token>
 ```
 
-All that you need to setup is specify `token` & `key` if you want to use it for your own. Or path(http or local) for _JSON_-encoded file, which contain one or more username for matching and `token` & `key` for each of them. It will be fetch or read in the moment of _POST_ request handling. How to get `token` & `key` see [below](#key--token).   
-The file structure should look like this:
+#### Per-User Tokens
 
+Put a file called `users.json` in the application root.
+
+The file structure should look like this:
 
 ```json
 {
@@ -40,21 +59,13 @@ The file structure should look like this:
 }
 ```
 
-If aliases is not specified, application will be use each key of object as alias.  
-By default the file name is `./users.json`. Of course you can change it in `USERS` environ variable.
-For example you can host `users.json` in your dropbox, it very useful if you want to change users dynamically.
+If aliases is not specified, application will be use each key of object as alias.
 
-### Deploy
+The location of this file can be customized by setting the `USERS` environment variable. This can also be set to a remote HTTP-accessible location and read on each POST hook run. For example you can host `users.json` in your dropbox, it very useful if you want to change users dynamically.
 
 ```
-$ heroku create
-$ heroku config:set KEY <your admin board key>
-$ heroku config:set TOKEN <your admin board token>
 $ heroku config:set USERS <your JSON file (https://dl.dropboxusercontent.com/s/a1nwtlzdpf/users.json)>
-$ git push heroku <current branch>:master
 ```
-If deploy was good, you can find application url in stdout. Usual it look like this: `https://sheltered-brook-4402.herokuapp.com`. This _URL_ to be useful in the next step.  
-After that you need setup you repo for webhook. Read about it [here](https://help.github.com/articles/post-receive-hooks) or [here](https://confluence.atlassian.com/display/BITBUCKET/POST+Service+Management).  
 
 ### Setup repo
 For setup the repo simply add your heroku app _URL_ + "/`<prefix>`/`<board_id>`" as a webhook url under "admin" for your repository. Where `<prefix>` is `g` for github or `b` for bitbucket. And `<board_id>` you can get from the Trello board _URL_, for example https://trello.com/board/trello-development/4d5ea62fd76aa1136000000c the board id is 4d5ea62fd76aa1136000000ca  

--- a/src/server/views/help.ls
+++ b/src/server/views/help.ls
@@ -43,6 +43,10 @@ exports.read-file = (url, next) ->
     return next err, body
 
   else
+    exists <~ fs.exists url
+    if !exists
+      console.log ("Could not read users file at #{url}. Assuming empty users object.")
+      return next null, {}
     err, body <~ fs.read-file url
     try body = JSON.parse body
     return next err, body

--- a/src/server/views/posthook.ls
+++ b/src/server/views/posthook.ls
@@ -14,7 +14,7 @@ default-commit = {}
 class BitBucketTrelloClient
 
   (@board, @payload, @token, @key) ->
-  
+
   URL:"https://api.trello.com/1/"
 
   sign: (url) ->
@@ -32,7 +32,7 @@ class BitBucketTrelloClient
     err, resp, body <~ request do
       url: @sign "#{@URL}cards/#{id}/actions/comments"
       method: "POST"
-      json: 
+      json:
         text: comment
 
     try body = JSON.parse body
@@ -57,7 +57,7 @@ class BitBucketTrelloClient
 
     err, card <~ @get-card commit.card
     return console.log ("" + err).red if err? && !(err == 1)
-    
+
     err <~ async.series [
       (cbk) ~>
         return cbk 1 if !commit.card? # card id not found => exit 1
@@ -74,23 +74,18 @@ class BitBucketTrelloClient
     return console.log ("" + err).red if err? && !(err == 1)
 
   set-action-author: (commit, next) ->
-    if !conf.users?
-      @token = conf.token
-      @key   = conf.key
-      return next!
-
     # cache for current http POST request
     err <~ (cbk) ~>
       return cbk null, @_people if @_people?
       err, people <~ help.read-file conf.users
       @_people = people
       unless typeof! people is "Object"
-        return next new Error("The type (#{typeof! people}) is not expected.")
+        return next new Error("Could not read users object from users configuration file. Expected Object but found #{typeof! people}.")
 
       cbk err
     return next err if err
 
-    
+
 
     for k,v of @_people
       for alias in v.aliases || [k]
@@ -111,7 +106,7 @@ class BitBucketTrelloClient
 class GitHubTrelloClient extends BitBucketTrelloClient
 
   get-commit-user: (commit) ->
-    commit.committer?.name 
+    commit.committer?.name
 
   make-message: (commit) ->
     "#{commit.committer.name}: #{commit.message}\n\n#{commit.url}"
@@ -122,7 +117,7 @@ module.exports = (req,res) ->
   err, resp, body <~ request url
   try body = JSON.parse body
   if //invalid//.test body
-    return res.send body 
+    return res.send body
 
   /**
    * LET'S GO


### PR DESCRIPTION
Starting 2ee8dfc, conf.users could no longer be null/undefined, and the
code block in the posthook's user resolver would never be hit. This
change accommodates a base use case where the users config property is
not set and where users.json does not exist. In that scenario, the
server will defer to the global token and key instead of failing a
couple lines later when it does a type check on the parsed people
object.
